### PR TITLE
タイトルが取得できないことがあるバグを修正

### DIFF
--- a/add.js
+++ b/add.js
@@ -56,7 +56,7 @@ async function appendBookmarkBtn(doc) {
             const chapterElem = document.querySelector('[aria-label="パンくずリスト"] li:nth-child(3) span');
             const title = 
                 contentType === 'guide' ? 
-                doc.querySelector('#iframe').contentDocument.querySelector("div.book-header>h1").textContent.trim() : 
+                doc.querySelector(".resource-title").textContent: 
                 (contentType === 'movie' ? doc.querySelector('h1>span').textContent : doc.querySelector('h1.resource-title').textContent);
 
             /** @type {Bookmark} */

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
     "manifest_version": 3,
     "name": "N Bookmarks",
     "description": "N予備校の教材をブックマークしたい",
-    "version": "1.0.5",
+    "version": "1.0.6",
     "permissions": [
         "storage"
     ],


### PR DESCRIPTION
取得方法を`div.book-header>h1`から`.resource-title`に変更。
コードも短くなったし、`book-header`がない教材にも対応できたはず。